### PR TITLE
feat: add template intro/outro pipeline support

### DIFF
--- a/tubearchive/cli.py
+++ b/tubearchive/cli.py
@@ -2043,9 +2043,7 @@ def run_pipeline(
             for i, video_file in enumerate(video_files)
         ]
 
-    fade_map = {
-        vf.path: FadeConfig(fade_in=0.0, fade_out=0.0) for vf in main_video_files if vf.path
-    }
+    fade_map = {vf.path: FadeConfig(fade_in=0.0, fade_out=0.0) for vf in main_video_files}
     fade_map.update(
         compute_fade_map(
             groups=groups,
@@ -2056,6 +2054,10 @@ def run_pipeline(
     video_files = list(main_video_files)
     if template_intro_video is not None:
         video_files.insert(0, template_intro_video)
+        fade_map[template_intro_video.path] = FadeConfig(
+            fade_in=validated_args.fade_duration,
+            fade_out=0.0,
+        )
         first_main = main_video_files[0]
         first_fade = fade_map.get(first_main.path)
         if first_fade is not None:
@@ -2066,6 +2068,10 @@ def run_pipeline(
 
     if template_outro_video is not None:
         video_files.append(template_outro_video)
+        fade_map[template_outro_video.path] = FadeConfig(
+            fade_in=0.0,
+            fade_out=validated_args.fade_duration,
+        )
         last_main = main_video_files[-1]
         last_fade = fade_map.get(last_main.path)
         if last_fade is not None:
@@ -2159,7 +2165,7 @@ def run_pipeline(
         notifier.notify(
             merge_complete_event(
                 output_path=str(final_path),
-                file_count=len(results),
+                file_count=len(main_results),
                 total_size_bytes=final_path.stat().st_size if final_path.exists() else 0,
             )
         )

--- a/tubearchive/config.py
+++ b/tubearchive/config.py
@@ -225,7 +225,8 @@ class NotificationConfig:
 class AppConfig:
     """애플리케이션 전체 설정.
 
-    [general] + [bgm] + [youtube] + [archive] + [color_grading] + [hooks] + [notification] 통합.
+    [general] + [bgm] + [youtube] + [archive] + [color_grading]
+    + [template] + [hooks] + [notification] 통합.
     """
 
     general: GeneralConfig = field(default_factory=GeneralConfig)
@@ -876,8 +877,8 @@ def generate_default_config() -> str:
 # gopro = "~/LUTs/gopro_flat_to_rec709.cube"
 
 [template]
-# intro = "~/templates/intro_intro.mp4"       # intro 템플릿 경로 (TUBEARCHIVE_TEMPLATE_INTRO)
-# outro = "~/templates/outro_outro.mp4"       # outro 템플릿 경로 (TUBEARCHIVE_TEMPLATE_OUTRO)
+# intro = "~/templates/intro.mp4"             # intro 템플릿 경로 (TUBEARCHIVE_TEMPLATE_INTRO)
+# outro = "~/templates/outro.mp4"             # outro 템플릿 경로 (TUBEARCHIVE_TEMPLATE_OUTRO)
 
 [notification]
 # enabled = false                         # 전역 알림 활성화 (TUBEARCHIVE_NOTIFY)


### PR DESCRIPTION
## 요약
- 병합 전/후에 intro/outro 템플릿 영상 삽입 옵션 추가
- 템플릿 경로 기본값 및 검증 처리
- 본편/템플릿 분기 기반 메타데이터, 아카이브 대상 및 리포트 집계 정합성 개선

## 변경 파일
- tubearchive/config.py
- tubearchive/cli.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Video templates: Intro and outro templates can now be configured and automatically integrated into video sequences with proper fade transitions and timing adjustments throughout the merge.
  * Template configuration: New settings subsystem supporting configuration files and environment variables for streamlined template path management and flexible deployment across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->