### PR TITLE
fix: detect GoPro/DJI/Nikon device model from camera-specific metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **언어**: Python 3.14+ (strict mypy)
 - **패키지 관리**: uv (poetry 사용 금지)
 
+### 시스템 의존성 (사전 설치 필요)
+
+| 도구 | 용도 | 설치 |
+|------|------|------|
+| `ffmpeg` / `ffprobe` | 트랜스코딩·메타데이터 추출 | `brew install ffmpeg` |
+| `exiftool` | 카메라 기기 모델 감지 (Nikon/Canon/Sony 등 MakerNote) | `brew install exiftool` |
+
+> exiftool이 없으면 iPhone/GoPro/DJI는 정상 감지되지만, Nikon·Canon·Sony 등 DSLR/미러리스 카메라의 기기 모델이 추출되지 않습니다 (경고 1회 출력).
+
 ## 명령어
 
 ```bash

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -165,6 +165,102 @@ class TestVideoRepository:
         with pytest.raises(sqlite3.IntegrityError):
             repo.insert(sample_video, sample_metadata)
 
+    def test_get_missing_device_model_returns_null_rows(
+        self,
+        repo: VideoRepository,
+        tmp_path: Path,
+        sample_metadata: VideoMetadata,
+    ) -> None:
+        """device_model이 NULL인 영상만 반환한다."""
+        # NULL device_model 영상 삽입
+        null_meta = VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=30.0,
+            fps=30.0,
+            codec="h264",
+            pixel_format="yuv420p",
+            is_portrait=False,
+            is_vfr=False,
+            device_model=None,
+            color_space=None,
+            color_transfer=None,
+            color_primaries=None,
+        )
+        p1 = tmp_path / "gopro.mp4"
+        p1.write_text("")
+        repo.insert(VideoFile(path=p1, creation_time=datetime(2024, 1, 1), size_bytes=1), null_meta)
+
+        # device_model 있는 영상 삽입
+        p2 = tmp_path / "iphone.mp4"
+        p2.write_text("")
+        repo.insert(
+            VideoFile(path=p2, creation_time=datetime(2024, 1, 2), size_bytes=1), sample_metadata
+        )
+
+        rows = repo.get_missing_device_model()
+        assert len(rows) == 1
+        assert rows[0]["original_path"] == str(p1)
+
+    def test_update_device_model(
+        self,
+        repo: VideoRepository,
+        tmp_path: Path,
+    ) -> None:
+        """device_model을 정상적으로 갱신한다."""
+        null_meta = VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=30.0,
+            fps=30.0,
+            codec="h264",
+            pixel_format="yuv420p",
+            is_portrait=False,
+            is_vfr=False,
+            device_model=None,
+            color_space=None,
+            color_transfer=None,
+            color_primaries=None,
+        )
+        p = tmp_path / "GH010001.mp4"
+        p.write_text("")
+        video_id = repo.insert(
+            VideoFile(path=p, creation_time=datetime(2024, 1, 1), size_bytes=1), null_meta
+        )
+
+        repo.update_device_model(video_id, "GoPro HERO 9")
+
+        row = repo.get_by_id(video_id)
+        assert row is not None
+        assert row["device_model"] == "GoPro HERO 9"
+
+    def test_get_missing_device_model_empty_string(
+        self,
+        repo: VideoRepository,
+        tmp_path: Path,
+    ) -> None:
+        """device_model이 빈 문자열인 영상도 반환한다."""
+        empty_meta = VideoMetadata(
+            width=1920,
+            height=1080,
+            duration_seconds=30.0,
+            fps=30.0,
+            codec="h264",
+            pixel_format="yuv420p",
+            is_portrait=False,
+            is_vfr=False,
+            device_model="",
+            color_space=None,
+            color_transfer=None,
+            color_primaries=None,
+        )
+        p = tmp_path / "nikon.mov"
+        p.write_text("")
+        repo.insert(VideoFile(path=p, creation_time=datetime(2024, 1, 1), size_bytes=1), empty_meta)
+
+        rows = repo.get_missing_device_model()
+        assert len(rows) == 1
+
 
 class TestTranscodingJobRepository:
     """TranscodingJobRepository 테스트."""

--- a/tests/unit/test_detector.py
+++ b/tests/unit/test_detector.py
@@ -1,11 +1,17 @@
 """메타데이터 감지기 테스트."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from tubearchive.domain.media.detector import _extract_device_model, detect_metadata
+from tubearchive.domain.media.detector import (
+    _build_device_name,
+    _extract_device_model,
+    _normalize_apple_model,
+    detect_metadata,
+)
 
 
 class TestDetector:
@@ -430,21 +436,34 @@ class TestExtractDeviceModel:
         probe = self._probe(video_handler="gopro H.265")
         assert _extract_device_model(probe, Path("GX010001.MP4")) == "GoPro"
 
-    def test_nikon_filename_mov(self) -> None:
-        probe = self._probe()
-        assert _extract_device_model(probe, Path("DSC_4885.MOV")) == "Nikon"
+    def test_apple_prefix_stripped(self) -> None:
+        """Blackmagic Camera 앱 촬영 파일: 'Apple ' 접두사 제거."""
+        probe = self._probe({"com.apple.quicktime.model": "Apple iPhone 17 Pro Max 100mm"})
+        assert _extract_device_model(probe, Path("A001_C001.mov")) == "iPhone 17 Pro Max"
 
-    def test_nikon_filename_mp4(self) -> None:
-        probe = self._probe()
-        assert _extract_device_model(probe, Path("DSC_1234.MP4")) == "Nikon"
+    def test_apple_lens_suffix_stripped(self) -> None:
+        probe = self._probe({"com.apple.quicktime.model": "Apple iPhone 17 Pro Max 24mm"})
+        assert _extract_device_model(probe, Path("A001_C002.mov")) == "iPhone 17 Pro Max"
 
-    def test_nikon_filename_case_insensitive(self) -> None:
+    def test_nikon_via_exiftool(self) -> None:
+        """Nikon DSC_ 파일은 exiftool로 감지한다 (파일명 휴리스틱 제거됨)."""
         probe = self._probe()
-        assert _extract_device_model(probe, Path("dsc_0001.mov")) == "Nikon"
+        exif_result = [{"SourceFile": "...", "Make": "NIKON CORPORATION", "Model": "NIKON Z 8"}]
+        with patch("tubearchive.domain.media.detector.subprocess.run") as mock_run:
+            mock_run.return_value.stdout = json.dumps(exif_result)
+            mock_run.return_value.returncode = 0
+            result = _extract_device_model(probe, Path("DSC_4885.MOV"))
+        assert result == "Nikon Z 8"
 
     def test_unknown_returns_none(self) -> None:
+        """exiftool도 Make/Model 없으면 None."""
         probe = self._probe()
-        assert _extract_device_model(probe, Path("unknown.mp4")) is None
+        exif_result = [{"SourceFile": "..."}]
+        with patch("tubearchive.domain.media.detector.subprocess.run") as mock_run:
+            mock_run.return_value.stdout = json.dumps(exif_result)
+            mock_run.return_value.returncode = 0
+            result = _extract_device_model(probe, Path("unknown.mp4"))
+        assert result is None
 
     def test_apple_priority_over_dji(self) -> None:
         probe = self._probe(
@@ -520,7 +539,8 @@ class TestExtractDeviceModel:
             metadata = detect_metadata(video_file)
         assert metadata.device_model == "DJI OsmoPocket3"
 
-    def test_detect_metadata_nikon_no_model_tag(self, tmp_path: Path) -> None:
+    def test_detect_metadata_nikon_via_exiftool(self, tmp_path: Path) -> None:
+        """detect_metadata 통합: exiftool 기반 Nikon Z 8 감지."""
         video_file = tmp_path / "DSC_4885.MOV"
         video_file.write_text("")
         probe_data = {
@@ -539,10 +559,75 @@ class TestExtractDeviceModel:
             ],
             "format": {
                 "duration": "45.0",
-                "tags": {"compatible_brands": "qt  niko"},
+                "tags": {},
             },
         }
-        with patch("tubearchive.domain.media.detector._run_ffprobe") as mock:
-            mock.return_value = probe_data
+        exif_result = [
+            {"SourceFile": str(video_file), "Make": "NIKON CORPORATION", "Model": "NIKON Z 8"}
+        ]
+        with (
+            patch("tubearchive.domain.media.detector._run_ffprobe") as mock_ffprobe,
+            patch("tubearchive.domain.media.detector.subprocess.run") as mock_exif,
+        ):
+            mock_ffprobe.return_value = probe_data
+            mock_exif.return_value.stdout = json.dumps(exif_result)
+            mock_exif.return_value.returncode = 0
             metadata = detect_metadata(video_file)
-        assert metadata.device_model == "Nikon"
+        assert metadata.device_model == "Nikon Z 8"
+
+
+class TestNormalizeAppleModel:
+    """_normalize_apple_model 정규화 테스트."""
+
+    def test_plain_iphone(self) -> None:
+        assert _normalize_apple_model("iPhone 17 Pro") == "iPhone 17 Pro"
+
+    def test_strips_apple_prefix(self) -> None:
+        assert _normalize_apple_model("Apple iPhone 17 Pro Max") == "iPhone 17 Pro Max"
+
+    def test_strips_apple_prefix_and_lens(self) -> None:
+        assert _normalize_apple_model("Apple iPhone 17 Pro Max 100mm") == "iPhone 17 Pro Max"
+
+    def test_strips_apple_prefix_24mm(self) -> None:
+        assert _normalize_apple_model("Apple iPhone 17 Pro Max 24mm") == "iPhone 17 Pro Max"
+
+    def test_no_change_without_prefix(self) -> None:
+        assert _normalize_apple_model("iPhone 14 Pro") == "iPhone 14 Pro"
+
+    def test_strips_whitespace(self) -> None:
+        assert _normalize_apple_model("  iPhone 17 Pro  ") == "iPhone 17 Pro"
+
+
+class TestBuildDeviceName:
+    """_build_device_name Make+Model 결합 테스트."""
+
+    def test_nikon(self) -> None:
+        assert _build_device_name("NIKON CORPORATION", "NIKON Z 8") == "Nikon Z 8"
+
+    def test_nikon_zfc(self) -> None:
+        assert _build_device_name("NIKON CORPORATION", "NIKON Z fc") == "Nikon Z fc"
+
+    def test_canon(self) -> None:
+        assert _build_device_name("Canon", "Canon EOS R5") == "Canon EOS R5"
+
+    def test_sony(self) -> None:
+        # Sony model is internal code — keep as-is with normalized make
+        result = _build_device_name("SONY", "ILCE-7M4")
+        assert result == "Sony ILCE-7M4"
+
+    def test_fujifilm(self) -> None:
+        assert _build_device_name("FUJIFILM", "X-T5") == "Fujifilm X-T5"
+
+    def test_gopro_no_make(self) -> None:
+        """GoPro exiftool: Make 없이 Model만 "HERO9 Black"."""
+        assert _build_device_name(None, "HERO9 Black") == "GoPro HERO9 Black"
+
+    def test_none_model_returns_none(self) -> None:
+        assert _build_device_name("NIKON CORPORATION", None) is None
+
+    def test_both_none_returns_none(self) -> None:
+        assert _build_device_name(None, None) is None
+
+    def test_unknown_make_title_case(self) -> None:
+        result = _build_device_name("ACME CORP", "Model X")
+        assert result == "Acme Model X"

--- a/tests/unit/test_detector.py
+++ b/tests/unit/test_detector.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tubearchive.domain.media.detector import detect_metadata
+from tubearchive.domain.media.detector import _extract_device_model, detect_metadata
 
 
 class TestDetector:
@@ -380,3 +380,169 @@ class TestDetector:
         assert metadata.location == "37.566500, 126.978000"
         assert metadata.location_latitude == 37.5665
         assert metadata.location_longitude == 126.9780
+
+
+class TestExtractDeviceModel:
+    """_extract_device_model 다중 소스 기기 감지 테스트."""
+
+    def _probe(
+        self,
+        format_tags: dict | None = None,
+        video_handler: str | None = None,
+    ) -> dict:
+        stream_tags = {}
+        if video_handler is not None:
+            stream_tags["handler_name"] = video_handler
+        return {
+            "streams": [{"codec_type": "video", "tags": stream_tags}],
+            "format": {"tags": format_tags or {}},
+        }
+
+    def test_apple_quicktime_model(self) -> None:
+        probe = self._probe({"com.apple.quicktime.model": "iPhone 17 Pro"})
+        assert _extract_device_model(probe, Path("IMG_0001.MOV")) == "iPhone 17 Pro"
+
+    def test_apple_model_strips_whitespace(self) -> None:
+        probe = self._probe({"com.apple.quicktime.model": "  iPhone 14 Pro  "})
+        assert _extract_device_model(probe, Path("IMG_0001.MOV")) == "iPhone 14 Pro"
+
+    def test_dji_encoder_tag(self) -> None:
+        probe = self._probe({"encoder": "DJI OsmoPocket3"})
+        assert _extract_device_model(probe, Path("DJI_20250118.MP4")) == "DJI OsmoPocket3"
+
+    def test_dji_case_insensitive(self) -> None:
+        probe = self._probe({"encoder": "dji Mini 4 Pro"})
+        assert _extract_device_model(probe, Path("DJI_0001.MP4")) == "dji Mini 4 Pro"
+
+    def test_gopro_firmware_hero9(self) -> None:
+        probe = self._probe({"firmware": "HD9.01.01.72.00"})
+        assert _extract_device_model(probe, Path("GH010001.MP4")) == "GoPro HERO 9"
+
+    def test_gopro_firmware_hero8(self) -> None:
+        probe = self._probe({"firmware": "HD8.01.02.50.00"})
+        assert _extract_device_model(probe, Path("GH010001.MP4")) == "GoPro HERO 8"
+
+    def test_gopro_handler_fallback(self) -> None:
+        probe = self._probe(video_handler="GoPro AVC  ")
+        assert _extract_device_model(probe, Path("GH010001.MP4")) == "GoPro"
+
+    def test_gopro_handler_case_insensitive(self) -> None:
+        probe = self._probe(video_handler="gopro H.265")
+        assert _extract_device_model(probe, Path("GX010001.MP4")) == "GoPro"
+
+    def test_nikon_filename_mov(self) -> None:
+        probe = self._probe()
+        assert _extract_device_model(probe, Path("DSC_4885.MOV")) == "Nikon"
+
+    def test_nikon_filename_mp4(self) -> None:
+        probe = self._probe()
+        assert _extract_device_model(probe, Path("DSC_1234.MP4")) == "Nikon"
+
+    def test_nikon_filename_case_insensitive(self) -> None:
+        probe = self._probe()
+        assert _extract_device_model(probe, Path("dsc_0001.mov")) == "Nikon"
+
+    def test_unknown_returns_none(self) -> None:
+        probe = self._probe()
+        assert _extract_device_model(probe, Path("unknown.mp4")) is None
+
+    def test_apple_priority_over_dji(self) -> None:
+        probe = self._probe(
+            {
+                "com.apple.quicktime.model": "iPhone 17 Pro",
+                "encoder": "DJI OsmoPocket3",
+            }
+        )
+        assert _extract_device_model(probe, Path("IMG_0001.MOV")) == "iPhone 17 Pro"
+
+    def test_dji_priority_over_gopro_firmware(self) -> None:
+        probe = self._probe({"encoder": "DJI OsmoPocket3", "firmware": "HD9.01.01.72.00"})
+        assert _extract_device_model(probe, Path("test.MP4")) == "DJI OsmoPocket3"
+
+    def test_gopro_firmware_priority_over_handler(self) -> None:
+        probe = self._probe(
+            format_tags={"firmware": "HD9.01.01.72.00"},
+            video_handler="GoPro AVC  ",
+        )
+        assert _extract_device_model(probe, Path("GH010001.MP4")) == "GoPro HERO 9"
+
+    def test_detect_metadata_gopro(self, tmp_path: Path) -> None:
+        video_file = tmp_path / "GH010001.MP4"
+        video_file.write_text("")
+        probe_data = {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 3840,
+                    "height": 2160,
+                    "pix_fmt": "yuv420p",
+                    "r_frame_rate": "60/1",
+                    "avg_frame_rate": "60/1",
+                    "duration": "30.0",
+                    "tags": {"handler_name": "GoPro AVC  "},
+                }
+            ],
+            "format": {
+                "duration": "30.0",
+                "tags": {"firmware": "HD9.01.01.72.00"},
+            },
+        }
+        with patch("tubearchive.domain.media.detector._run_ffprobe") as mock:
+            mock.return_value = probe_data
+            metadata = detect_metadata(video_file)
+        assert metadata.device_model == "GoPro HERO 9"
+
+    def test_detect_metadata_dji(self, tmp_path: Path) -> None:
+        video_file = tmp_path / "DJI_20250118.MP4"
+        video_file.write_text("")
+        probe_data = {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 1920,
+                    "height": 1080,
+                    "pix_fmt": "yuv420p",
+                    "r_frame_rate": "30/1",
+                    "avg_frame_rate": "30/1",
+                    "duration": "20.0",
+                    "tags": {},
+                }
+            ],
+            "format": {
+                "duration": "20.0",
+                "tags": {"encoder": "DJI OsmoPocket3"},
+            },
+        }
+        with patch("tubearchive.domain.media.detector._run_ffprobe") as mock:
+            mock.return_value = probe_data
+            metadata = detect_metadata(video_file)
+        assert metadata.device_model == "DJI OsmoPocket3"
+
+    def test_detect_metadata_nikon_no_model_tag(self, tmp_path: Path) -> None:
+        video_file = tmp_path / "DSC_4885.MOV"
+        video_file.write_text("")
+        probe_data = {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "codec_name": "h264",
+                    "width": 3840,
+                    "height": 2160,
+                    "pix_fmt": "yuv420p",
+                    "r_frame_rate": "60/1",
+                    "avg_frame_rate": "60/1",
+                    "duration": "45.0",
+                    "tags": {},
+                }
+            ],
+            "format": {
+                "duration": "45.0",
+                "tags": {"compatible_brands": "qt  niko"},
+            },
+        }
+        with patch("tubearchive.domain.media.detector._run_ffprobe") as mock:
+            mock.return_value = probe_data
+            metadata = detect_metadata(video_file)
+        assert metadata.device_model == "Nikon"

--- a/tests/unit/test_fix_device_models.py
+++ b/tests/unit/test_fix_device_models.py
@@ -1,0 +1,193 @@
+"""cmd_fix_device_models 단위 테스트."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tubearchive.domain.models.video import VideoFile, VideoMetadata
+from tubearchive.infra.db.repository import VideoRepository
+from tubearchive.infra.db.schema import init_database
+
+
+def _null_meta(path: Path) -> tuple[VideoFile, VideoMetadata]:
+    """device_model=None 인 VideoFile/VideoMetadata 쌍 생성."""
+    return VideoFile(path=path, creation_time=datetime(2024, 1, 1), size_bytes=1), VideoMetadata(
+        width=3840,
+        height=2160,
+        duration_seconds=30.0,
+        fps=60.0,
+        codec="h264",
+        pixel_format="yuv420p",
+        is_portrait=False,
+        is_vfr=False,
+        device_model=None,
+        color_space=None,
+        color_transfer=None,
+        color_primaries=None,
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    db = tmp_path / "test.db"
+    conn = init_database(db)
+    conn.close()
+    return db
+
+
+class TestCmdFixDeviceModels:
+    """cmd_fix_device_models 동작 검증."""
+
+    def _insert_null(self, conn: sqlite3.Connection, path: Path) -> int:
+        video_file, meta = _null_meta(path)
+        return VideoRepository(conn).insert(video_file, meta)
+
+    def test_no_records_prints_empty_message(
+        self, db_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """NULL 레코드가 없으면 안내 메시지만 출력."""
+        with patch("tubearchive.app.cli.main.database_session") as mock_session:
+            conn = init_database(db_path)
+            mock_session.return_value.__enter__ = lambda s: conn
+            mock_session.return_value.__exit__ = lambda s, *a: conn.close()
+
+            from tubearchive.app.cli.main import cmd_fix_device_models
+
+            cmd_fix_device_models()
+
+        captured = capsys.readouterr()
+        assert "없습니다" in captured.out
+
+    def test_updates_detected_model(
+        self, tmp_path: Path, db_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """ffprobe 결과로 모델 감지되면 DB를 갱신한다."""
+        gopro_path = tmp_path / "GH010001.MP4"
+        gopro_path.write_text("")
+
+        conn = init_database(db_path)
+        video_id = self._insert_null(conn, gopro_path)
+        conn.close()
+
+        probe_result = {
+            "streams": [{"codec_type": "video", "tags": {"handler_name": "GoPro AVC"}}],
+            "format": {"tags": {"firmware": "HD9.01.01.72.00"}},
+        }
+
+        call_count = [0]
+
+        def mock_session():
+            import contextlib
+
+            @contextlib.contextmanager
+            def _ctx():
+                c = sqlite3.connect(str(db_path))
+                c.row_factory = sqlite3.Row
+                try:
+                    yield c
+                finally:
+                    c.close()
+
+            call_count[0] += 1
+            return _ctx()
+
+        with (
+            patch("tubearchive.app.cli.main.database_session", mock_session),
+            patch("tubearchive.app.cli.main.Path", wraps=Path),
+            patch("tubearchive.domain.media.detector._run_ffprobe", return_value=probe_result),
+        ):
+            from tubearchive.app.cli.main import cmd_fix_device_models
+
+            cmd_fix_device_models()
+
+        captured = capsys.readouterr()
+        assert "1개 갱신" in captured.out
+
+        conn2 = sqlite3.connect(str(db_path))
+        conn2.row_factory = sqlite3.Row
+        row = conn2.execute("SELECT device_model FROM videos WHERE id = ?", (video_id,)).fetchone()
+        conn2.close()
+        assert row["device_model"] == "GoPro HERO 9"
+
+    def test_skips_missing_file(
+        self, tmp_path: Path, db_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """파일이 존재하지 않으면 건너뛴다."""
+        missing_path = tmp_path / "nonexistent.MP4"
+        missing_path.write_text("")  # VideoFile 생성을 위해 임시 생성 후 삭제
+
+        conn = init_database(db_path)
+        self._insert_null(conn, missing_path)
+        conn.close()
+
+        missing_path.unlink()  # 파일 삭제 — cmd_fix_device_models에서 건너뜀 대상
+
+        def mock_session():
+            import contextlib
+
+            @contextlib.contextmanager
+            def _ctx():
+                c = sqlite3.connect(str(db_path))
+                c.row_factory = sqlite3.Row
+                try:
+                    yield c
+                finally:
+                    c.close()
+
+            return _ctx()
+
+        with patch("tubearchive.app.cli.main.database_session", mock_session):
+            from tubearchive.app.cli.main import cmd_fix_device_models
+
+            cmd_fix_device_models()
+
+        captured = capsys.readouterr()
+        assert "1개 파일 없음" in captured.out
+        assert "0개 갱신" in captured.out
+
+    def test_skips_undetectable_model(
+        self, tmp_path: Path, db_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """모델 감지 불가 파일은 건너뛴다."""
+        unknown_path = tmp_path / "unknown_camera.mp4"
+        unknown_path.write_text("")
+
+        conn = init_database(db_path)
+        self._insert_null(conn, unknown_path)
+        conn.close()
+
+        probe_result = {
+            "streams": [{"codec_type": "video", "tags": {}}],
+            "format": {"tags": {}},
+        }
+
+        def mock_session():
+            import contextlib
+
+            @contextlib.contextmanager
+            def _ctx():
+                c = sqlite3.connect(str(db_path))
+                c.row_factory = sqlite3.Row
+                try:
+                    yield c
+                finally:
+                    c.close()
+
+            return _ctx()
+
+        with (
+            patch("tubearchive.app.cli.main.database_session", mock_session),
+            patch("tubearchive.domain.media.detector._run_ffprobe", return_value=probe_result),
+        ):
+            from tubearchive.app.cli.main import cmd_fix_device_models
+
+            cmd_fix_device_models()
+
+        captured = capsys.readouterr()
+        assert "0개 갱신" in captured.out
+        assert "1개 모델 감지 불가" in captured.out

--- a/tubearchive/app/cli/main.py
+++ b/tubearchive/app/cli/main.py
@@ -4115,24 +4115,29 @@ def cmd_status_detail(job_id: int) -> None:
 
 
 def cmd_fix_device_models() -> None:
-    """``--fix-device-models`` 처리: device_model이 NULL인 영상을 재스캔하여 채운다.
+    """``--fix-device-models`` 처리: device_model을 재스캔하여 채우거나 수정한다.
 
-    DB에서 device_model이 비어 있는 영상을 조회하고, 파일이 존재하면
-    ffprobe로 재감지하여 모델명을 갱신한다. 파일이 없거나 감지 실패 시 건너뛴다.
+    대상:
+    - device_model이 NULL/빈 문자열
+    - 파일명 휴리스틱으로 채운 ``"Nikon"`` (exiftool로 정확한 모델명으로 교체)
+    - 정규화 전 Apple 접두사 값 (``"Apple iPhone..."`` → ``"iPhone..."``)
+
+    파일이 존재하면 ffprobe + exiftool로 재감지하여 모델명을 갱신한다.
+    파일이 없거나 감지 실패 시 건너뛴다.
     """
     from tubearchive.domain.media.detector import _extract_device_model, _run_ffprobe
     from tubearchive.infra.db.repository import VideoRepository
 
     with database_session() as conn:
         repo = VideoRepository(conn)
-        rows = repo.get_missing_device_model()
+        rows = repo.get_missing_device_model(include_heuristic=True)
 
     total = len(rows)
     if total == 0:
-        print("device_model이 비어 있는 영상이 없습니다.")
+        print("재감지가 필요한 영상이 없습니다.")
         return
 
-    print(f"device_model 누락 영상 {total}개 재스캔 시작...")
+    print(f"device_model 재스캔 대상 {total}개 처리 시작...")
 
     updated = 0
     skipped_missing = 0

--- a/tubearchive/app/cli/main.py
+++ b/tubearchive/app/cli/main.py
@@ -987,6 +987,12 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--fix-device-models",
+        action="store_true",
+        help="DB에서 device_model이 비어 있는 영상을 재스캔하여 기기 모델을 채운다",
+    )
+
+    parser.add_argument(
         "--catalog",
         action="store_true",
         help="영상 메타데이터 전체 목록 조회 (기기별 그룹핑)",
@@ -4108,6 +4114,64 @@ def cmd_status_detail(job_id: int) -> None:
         print("=" * 60)
 
 
+def cmd_fix_device_models() -> None:
+    """``--fix-device-models`` 처리: device_model이 NULL인 영상을 재스캔하여 채운다.
+
+    DB에서 device_model이 비어 있는 영상을 조회하고, 파일이 존재하면
+    ffprobe로 재감지하여 모델명을 갱신한다. 파일이 없거나 감지 실패 시 건너뛴다.
+    """
+    from tubearchive.domain.media.detector import _extract_device_model, _run_ffprobe
+    from tubearchive.infra.db.repository import VideoRepository
+
+    with database_session() as conn:
+        repo = VideoRepository(conn)
+        rows = repo.get_missing_device_model()
+
+    total = len(rows)
+    if total == 0:
+        print("device_model이 비어 있는 영상이 없습니다.")
+        return
+
+    print(f"device_model 누락 영상 {total}개 재스캔 시작...")
+
+    updated = 0
+    skipped_missing = 0
+    skipped_no_model = 0
+
+    for row in rows:
+        video_id: int = row["id"]
+        path = Path(row["original_path"])
+
+        if not path.exists():
+            skipped_missing += 1
+            logger.debug("파일 없음, 건너뜀: %s", path)
+            continue
+
+        try:
+            probe_data = _run_ffprobe(path)
+            device_model = _extract_device_model(probe_data, path)
+        except Exception as exc:
+            logger.debug("ffprobe 실패 (%s): %s", path.name, exc)
+            skipped_no_model += 1
+            continue
+
+        if not device_model:
+            skipped_no_model += 1
+            logger.debug("모델 감지 불가: %s", path.name)
+            continue
+
+        with database_session() as conn:
+            VideoRepository(conn).update_device_model(video_id, device_model)
+        updated += 1
+        logger.info("갱신: %s → %s", path.name, device_model)
+
+    print(
+        f"완료: {updated}개 갱신"
+        f", {skipped_missing}개 파일 없음"
+        f", {skipped_no_model}개 모델 감지 불가"
+    )
+
+
 def _cmd_dry_run(validated_args: ValidatedArgs) -> None:
     """실행 계획만 출력하고 실제 트랜스코딩은 수행하지 않는다.
 
@@ -4606,6 +4670,11 @@ def main() -> None:
         # --reset-upload 옵션 처리 (업로드 기록 초기화)
         if args.reset_upload is not None:
             cmd_reset_upload(args.reset_upload)
+            return
+
+        # --fix-device-models 옵션 처리 (device_model 소급 수정)
+        if args.fix_device_models:
+            cmd_fix_device_models()
             return
 
         # --project-list 옵션 처리 (프로젝트 목록 조회)

--- a/tubearchive/domain/media/detector.py
+++ b/tubearchive/domain/media/detector.py
@@ -434,7 +434,7 @@ def detect_metadata(video_path: Path) -> VideoMetadata:
     is_portrait = is_rotated_vertical or (width < height)
 
     # 기기 모델 감지
-    device_model = probe_data.get("format", {}).get("tags", {}).get("com.apple.quicktime.model")
+    device_model = _extract_device_model(probe_data, video_path)
 
     # 위치 감지: ISO6709 / Lat/Lon 개별 필드
     location = _extract_location(probe_data)
@@ -479,6 +479,55 @@ def detect_metadata(video_path: Path) -> VideoMetadata:
         location=location,
         has_audio=has_audio,
     )
+
+
+_GOPRO_FIRMWARE_RE = re.compile(r"^HD(\d+)\.", re.IGNORECASE)
+
+
+def _extract_device_model(probe_data: dict[str, Any], video_path: Path) -> str | None:
+    """다양한 카메라 제조사 태그에서 기기 모델을 추출한다.
+
+    우선순위:
+    1. ``com.apple.quicktime.model`` — iPhone / iPad
+    2. ``format.tags.encoder`` 가 "DJI"로 시작 — DJI 카메라
+    3. ``format.tags.firmware`` "HD{n}.*" 패턴 — GoPro HERO {n}
+    4. 비디오 스트림 ``handler_name`` 에 "gopro" 포함 — GoPro (모델 불명)
+    5. 파일명 "DSC_*.MOV/.MP4" — Nikon
+    """
+    format_tags = probe_data.get("format", {}).get("tags", {})
+
+    # 1) Apple QuickTime (iPhone, iPad)
+    apple_model = format_tags.get("com.apple.quicktime.model")
+    if isinstance(apple_model, str) and apple_model.strip():
+        return apple_model.strip()
+
+    # 2) DJI: format.tags.encoder starts with "DJI"
+    encoder = format_tags.get("encoder", "")
+    if isinstance(encoder, str) and encoder.upper().startswith("DJI"):
+        return encoder.strip()
+
+    # 3) GoPro: format.tags.firmware "HD{n}.x.x" → "GoPro HERO {n}"
+    firmware = format_tags.get("firmware", "")
+    if isinstance(firmware, str):
+        m = _GOPRO_FIRMWARE_RE.match(firmware)
+        if m:
+            return f"GoPro HERO {m.group(1)}"
+
+    # 4) GoPro: video stream handler_name contains "gopro"
+    for stream in probe_data.get("streams", []):
+        if stream.get("codec_type") != "video":
+            continue
+        handler = stream.get("tags", {}).get("handler_name", "")
+        if isinstance(handler, str) and "gopro" in handler.lower():
+            return "GoPro"
+
+    # 5) Nikon: filename pattern DSC_*.MOV / DSC_*.MP4
+    stem = video_path.stem.upper()
+    suffix = video_path.suffix.upper()
+    if stem.startswith("DSC_") and suffix in (".MOV", ".MP4"):
+        return "Nikon"
+
+    return None
 
 
 def _run_ffprobe(video_path: Path) -> dict[str, Any]:

--- a/tubearchive/domain/media/detector.py
+++ b/tubearchive/domain/media/detector.py
@@ -482,24 +482,138 @@ def detect_metadata(video_path: Path) -> VideoMetadata:
 
 
 _GOPRO_FIRMWARE_RE = re.compile(r"^HD(\d+)\.", re.IGNORECASE)
+_APPLE_MODEL_LENS_RE = re.compile(r"\s+\d+mm$", re.IGNORECASE)
+
+# exiftool Make 필드 정규화 테이블
+_MAKE_OVERRIDES: dict[str, str] = {
+    "NIKON CORPORATION": "Nikon",
+    "NIKON": "Nikon",
+    "CANON INC.": "Canon",
+    "CANON": "Canon",
+    "SONY": "Sony",
+    "FUJIFILM": "Fujifilm",
+    "PANASONIC": "Panasonic",
+    "OM DIGITAL SOLUTIONS": "OM System",
+    "OLYMPUS CORPORATION": "Olympus",
+    "OLYMPUS IMAGING CORP.": "Olympus",
+    "APPLE": "Apple",
+}
+
+# exiftool 미설치 경고는 1회만 출력
+_exiftool_missing_warned = False
+
+
+def _normalize_apple_model(raw: str) -> str:
+    """iPhone/iPad 모델명을 정규화한다.
+
+    - ``"Apple "`` 접두사 제거 (Blackmagic Camera 앱 등)
+    - `` NNmm`` 렌즈 접미사 제거 (Blackmagic Camera 촬영 파일)
+
+    Examples::
+
+        "Apple iPhone 17 Pro Max 100mm" → "iPhone 17 Pro Max"
+        "iPhone 17 Pro"                 → "iPhone 17 Pro"
+    """
+    model = raw.strip()
+    if model.startswith("Apple "):
+        model = model[6:].strip()
+    return _APPLE_MODEL_LENS_RE.sub("", model).strip()
+
+
+def _normalize_make(raw_make: str) -> str:
+    """제조사 문자열을 표시용 이름으로 정규화한다."""
+    upper = raw_make.strip().upper()
+    for key, normalized in _MAKE_OVERRIDES.items():
+        if upper == key:
+            return normalized
+    # 알 수 없는 제조사: 첫 단어를 Title Case로
+    first = raw_make.strip().split()[0] if raw_make.strip() else ""
+    return first.title() if first else raw_make.strip()
+
+
+def _build_device_name(make: str | None, model: str | None) -> str | None:
+    """exiftool Make + Model을 결합하여 표시용 기기명을 반환한다.
+
+    - Make 정규화 후 Model의 중복 접두사 제거
+    - GoPro는 Make 없이 Model만 있을 수 있어 "GoPro " 접두사를 보완
+    """
+    if not model:
+        return None
+    model = model.strip()
+    if not model:
+        return None
+
+    # GoPro: Make 없이 Model이 "HERO"로 시작
+    if not make and model.upper().startswith("HERO"):
+        return f"GoPro {model}"
+
+    if not make:
+        return model
+
+    norm_make = _normalize_make(make)
+
+    # Model에 Make 접두사가 포함된 경우 제거 ("NIKON Z 8" → "Z 8" under make "Nikon")
+    model_upper = model.upper()
+    for prefix in (make.strip().upper(), norm_make.upper()):
+        if prefix and model_upper.startswith(prefix):
+            model = model[len(prefix) :].strip()
+            break
+
+    return f"{norm_make} {model}".strip() if model else norm_make
+
+
+def _run_exiftool(video_path: Path) -> dict[str, Any]:
+    """exiftool로 Make/Model 태그를 추출한다.
+
+    exiftool이 설치되지 않은 경우 경고를 1회 출력하고 빈 dict를 반환한다.
+
+    Args:
+        video_path: 분석할 영상 파일 경로.
+
+    Returns:
+        ``{"Make": ..., "Model": ...}`` 형태의 dict. 태그가 없으면 빈 dict.
+    """
+    global _exiftool_missing_warned
+
+    cmd = ["exiftool", "-j", "-Make", "-Model", str(video_path)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        data: list[dict[str, Any]] = json.loads(result.stdout)
+        return data[0] if data else {}
+    except FileNotFoundError:
+        if not _exiftool_missing_warned:
+            logger.warning(
+                "exiftool을 찾을 수 없습니다. Nikon/Canon/Sony 등의 카메라 모델 감지가 "
+                "제한됩니다. 설치: brew install exiftool  (https://exiftool.org)"
+            )
+            _exiftool_missing_warned = True
+        return {}
+    except (subprocess.CalledProcessError, json.JSONDecodeError, subprocess.TimeoutExpired):
+        return {}
 
 
 def _extract_device_model(probe_data: dict[str, Any], video_path: Path) -> str | None:
     """다양한 카메라 제조사 태그에서 기기 모델을 추출한다.
 
     우선순위:
-    1. ``com.apple.quicktime.model`` — iPhone / iPad
+    1. ``com.apple.quicktime.model`` — iPhone / iPad (정규화 적용)
     2. ``format.tags.encoder`` 가 "DJI"로 시작 — DJI 카메라
     3. ``format.tags.firmware`` "HD{n}.*" 패턴 — GoPro HERO {n}
     4. 비디오 스트림 ``handler_name`` 에 "gopro" 포함 — GoPro (모델 불명)
-    5. 파일명 "DSC_*.MOV/.MP4" — Nikon
+    5. exiftool Make + Model — Nikon / Canon / Sony / Fujifilm 등
     """
     format_tags = probe_data.get("format", {}).get("tags", {})
 
-    # 1) Apple QuickTime (iPhone, iPad)
+    # 1) Apple QuickTime (iPhone, iPad) — "Apple " 접두사·렌즈 접미사 정규화
     apple_model = format_tags.get("com.apple.quicktime.model")
     if isinstance(apple_model, str) and apple_model.strip():
-        return apple_model.strip()
+        return _normalize_apple_model(apple_model)
 
     # 2) DJI: format.tags.encoder starts with "DJI"
     encoder = format_tags.get("encoder", "")
@@ -521,13 +635,9 @@ def _extract_device_model(probe_data: dict[str, Any], video_path: Path) -> str |
         if isinstance(handler, str) and "gopro" in handler.lower():
             return "GoPro"
 
-    # 5) Nikon: filename pattern DSC_*.MOV / DSC_*.MP4
-    stem = video_path.stem.upper()
-    suffix = video_path.suffix.upper()
-    if stem.startswith("DSC_") and suffix in (".MOV", ".MP4"):
-        return "Nikon"
-
-    return None
+    # 5) exiftool: Nikon / Canon / Sony 등 MakerNote 기반 카메라
+    exif = _run_exiftool(video_path)
+    return _build_device_name(exif.get("Make"), exif.get("Model"))
 
 
 def _run_ffprobe(video_path: Path) -> dict[str, Any]:

--- a/tubearchive/infra/db/repository.py
+++ b/tubearchive/infra/db/repository.py
@@ -148,6 +148,23 @@ class VideoRepository:
             "devices": [(r["device"], int(r["cnt"])) for r in device_rows],
         }
 
+    def get_missing_device_model(self) -> list[sqlite3.Row]:
+        """device_model이 비어 있는 영상 목록을 반환한다."""
+        cursor = self.conn.execute(
+            "SELECT id, original_path FROM videos"
+            " WHERE device_model IS NULL OR device_model = ''"
+            " ORDER BY id"
+        )
+        return cursor.fetchall()
+
+    def update_device_model(self, video_id: int, device_model: str) -> None:
+        """영상의 device_model을 갱신한다."""
+        self.conn.execute(
+            "UPDATE videos SET device_model = ? WHERE id = ?",
+            (device_model, video_id),
+        )
+        self.conn.commit()
+
     def delete_by_ids(self, video_ids: list[int]) -> int:
         """여러 영상을 ID 목록으로 일괄 삭제한다.
 

--- a/tubearchive/infra/db/repository.py
+++ b/tubearchive/infra/db/repository.py
@@ -148,13 +148,27 @@ class VideoRepository:
             "devices": [(r["device"], int(r["cnt"])) for r in device_rows],
         }
 
-    def get_missing_device_model(self) -> list[sqlite3.Row]:
-        """device_model이 비어 있는 영상 목록을 반환한다."""
-        cursor = self.conn.execute(
-            "SELECT id, original_path FROM videos"
-            " WHERE device_model IS NULL OR device_model = ''"
-            " ORDER BY id"
-        )
+    def get_missing_device_model(self, include_heuristic: bool = False) -> list[sqlite3.Row]:
+        """device_model이 비어 있거나 재감지가 필요한 영상 목록을 반환한다.
+
+        Args:
+            include_heuristic: True이면 파일명 휴리스틱으로 채운 값(``"Nikon"``)과
+                정규화 전 Apple 접두사 값(``"Apple iPhone..."``)도 포함한다.
+        """
+        if include_heuristic:
+            cursor = self.conn.execute(
+                "SELECT id, original_path FROM videos"
+                " WHERE device_model IS NULL OR device_model = ''"
+                "    OR device_model = 'Nikon'"
+                "    OR device_model LIKE 'Apple iPhone%'"
+                " ORDER BY id"
+            )
+        else:
+            cursor = self.conn.execute(
+                "SELECT id, original_path FROM videos"
+                " WHERE device_model IS NULL OR device_model = ''"
+                " ORDER BY id"
+            )
         return cursor.fetchall()
 
     def update_device_model(self, video_id: int, device_model: str) -> None:


### PR DESCRIPTION
## Summary

- DSC_ 파일명 휴리스틱 제거 → exiftool MakerNote 기반으로 교체 (Nikon/Canon/Sony/Fujifilm 등 DSLR·미러리스 정확 감지)
- `_normalize_apple_model()` 추가: `"Apple iPhone 17 Pro Max 100mm"` → `"iPhone 17 Pro Max"` (Blackmagic Camera 앱 호환)
- `get_missing_device_model(include_heuristic=True)` 추가: 기존 파일명 기반 "Nikon" 177개 + "Apple iPhone" 3개 소급 재감지
- exiftool 미설치 시 warning 1회 출력 후 graceful 폴백 (crash 없음)

## Changed files

| 파일 | 변경 내용 |
|------|----------|
| \`tubearchive/domain/media/detector.py\` | \`_run_exiftool()\`, \`_build_device_name()\`, \`_normalize_apple_model()\`, \`_normalize_make()\` 추가; DSC_ 휴리스틱 제거 |
| \`tubearchive/infra/db/repository.py\` | \`get_missing_device_model(include_heuristic=True)\` |
| \`tubearchive/app/cli/main.py\` | \`cmd_fix_device_models()\` → \`include_heuristic=True\` 사용 |
| \`CLAUDE.md\` | exiftool 필수 시스템 의존성 명시 |
| \`tests/unit/test_detector.py\` | exiftool 모킹 테스트, \`TestNormalizeAppleModel\`, \`TestBuildDeviceName\` 추가 |

## Test plan

- [x] \`uv run pytest tests/unit/test_detector.py -v\` — 45 passed
- [x] \`uv run pytest tests/unit/ -q\` — 1292 passed
- [x] \`uv run mypy tubearchive/\` — no issues
- [x] \`uv run ruff check tubearchive/ tests/\` — no issues
- [x] \`uv run tubearchive --fix-device-models\` — 실 DB에서 177 Nikon + 3 Apple iPhone 소급 수정 확인