### PR TITLE
fix: --denoise + --normalize-audio 조합에서 오디오 손실 수정 (closes #66)

### DIFF
--- a/tests/unit/test_transcoder.py
+++ b/tests/unit/test_transcoder.py
@@ -175,6 +175,77 @@ class TestTranscoderLoudnorm:
         assert loudnorm_arg is not None
         assert loudnorm_arg.input_i == pytest.approx(-24.5)
 
+    def test_denoise_with_normalize_passes_denoise_as_pre_filter(
+        self,
+        mock_transcoder: MagicMock,
+        mock_metadata: MagicMock,
+        video_file: MagicMock,
+        loudnorm_stderr: str,
+    ) -> None:
+        """denoise + normalize_audio 동시 사용 시 loudnorm 1st pass에 denoise 필터가 포함된다.
+
+        loudnorm 1st pass는 2nd pass의 실제 입력(denoise 처리 후)과 동일한 오디오를
+        측정해야 측정값과 입력이 일치한다. 불일치 시 오디오 손실이 발생한다 (issue #66).
+        """
+        mock_metadata.has_audio = True
+        with (
+            patch(
+                "tubearchive.domain.media.transcoder.detect_metadata", return_value=mock_metadata
+            ),
+            patch("tubearchive.domain.media.transcoder.create_combined_filter") as mock_filter,
+        ):
+            mock_filter.return_value = ("scale=3840:2160", "afade=t=in:st=0:d=0.5")
+            mock_transcoder.executor.run.return_value = None
+            mock_transcoder.executor.run_analysis.return_value = loudnorm_stderr
+            mock_transcoder.executor.build_loudness_analysis_command.return_value = ["ffmpeg"]
+            with contextlib.suppress(Exception):
+                mock_transcoder.transcode_video(
+                    video_file,
+                    normalize_audio=True,
+                    denoise=True,
+                    denoise_level="medium",
+                )
+
+        build_call = mock_transcoder.executor.build_loudness_analysis_command.call_args
+        assert build_call is not None
+        audio_filter = build_call.kwargs.get("audio_filter") or build_call.args[1]
+        # denoise 필터(afftdn)가 loudnorm 분석 필터 앞에 포함되어야 한다
+        assert "afftdn" in audio_filter
+        assert "loudnorm" in audio_filter
+        assert audio_filter.index("afftdn") < audio_filter.index("loudnorm")
+
+    def test_normalize_only_no_denoise_pre_filter(
+        self,
+        mock_transcoder: MagicMock,
+        mock_metadata: MagicMock,
+        video_file: MagicMock,
+        loudnorm_stderr: str,
+    ) -> None:
+        """denoise=False이면 loudnorm 1st pass에 afftdn이 포함되지 않는다."""
+        mock_metadata.has_audio = True
+        with (
+            patch(
+                "tubearchive.domain.media.transcoder.detect_metadata", return_value=mock_metadata
+            ),
+            patch("tubearchive.domain.media.transcoder.create_combined_filter") as mock_filter,
+        ):
+            mock_filter.return_value = ("scale=3840:2160", "afade=t=in:st=0:d=0.5")
+            mock_transcoder.executor.run.return_value = None
+            mock_transcoder.executor.run_analysis.return_value = loudnorm_stderr
+            mock_transcoder.executor.build_loudness_analysis_command.return_value = ["ffmpeg"]
+            with contextlib.suppress(Exception):
+                mock_transcoder.transcode_video(
+                    video_file,
+                    normalize_audio=True,
+                    denoise=False,
+                )
+
+        build_call = mock_transcoder.executor.build_loudness_analysis_command.call_args
+        assert build_call is not None
+        audio_filter = build_call.kwargs.get("audio_filter") or build_call.args[1]
+        assert "afftdn" not in audio_filter
+        assert "loudnorm" in audio_filter
+
 
 class TestTranscoderVidstab:
     """Transcoder의 vidstab 2-pass 통합 테스트."""

--- a/tubearchive/domain/media/transcoder.py
+++ b/tubearchive/domain/media/transcoder.py
@@ -28,6 +28,7 @@ from tubearchive.infra.ffmpeg.effects import (
     StabilizeCrop,
     StabilizeStrength,
     create_combined_filter,
+    create_denoise_audio_filter,
     create_loudnorm_analysis_filter,
     create_vidstab_detect_filter,
     create_vidstab_transform_filter,
@@ -244,7 +245,11 @@ class Transcoder:
 
     # ---------- 공개 API ----------
 
-    def _run_loudnorm_analysis(self, video_file: VideoFile) -> LoudnormAnalysis:
+    def _run_loudnorm_analysis(
+        self,
+        video_file: VideoFile,
+        pre_filter: str = "",
+    ) -> LoudnormAnalysis:
         """EBU R128 loudnorm 1st pass — 오디오 라우드니스 분석.
 
         FFmpeg의 ``loudnorm`` 필터를 분석 모드(``print_format=json``)로
@@ -253,14 +258,17 @@ class Transcoder:
 
         Args:
             video_file: 분석 대상 영상 파일.
+            pre_filter: loudnorm 앞에 적용할 오디오 필터 (예: denoise 필터).
+                2nd pass의 실제 입력과 측정 환경을 일치시키기 위해 사용한다.
 
         Returns:
             1st pass 분석 결과 (:class:`LoudnormAnalysis`).
         """
         analysis_filter = create_loudnorm_analysis_filter()
+        full_filter = f"{pre_filter},{analysis_filter}" if pre_filter else analysis_filter
         cmd = self.executor.build_loudness_analysis_command(
             input_path=video_file.path,
-            audio_filter=analysis_filter,
+            audio_filter=full_filter,
         )
         logger.info("Running loudnorm analysis pass")
         stderr = self.executor.run_analysis(cmd)
@@ -439,11 +447,14 @@ class Transcoder:
         self.resume_mgr.set_temp_file(job_id, output_path)
 
         # 5. loudnorm 분석 (활성화된 경우, 트랜스코딩 전에 실행)
-        # 오디오 스트림이 없는 영상에서는 오디오 분석을 스킵한다
+        # 오디오 스트림이 없는 영상에서는 오디오 분석을 스킵한다.
+        # denoise가 함께 활성화된 경우, 1st pass도 denoise를 거친 오디오를 측정해야
+        # 2nd pass와 측정 환경이 일치하여 loudnorm 특성 불일치를 방지한다.
         loudnorm_analysis: LoudnormAnalysis | None = None
         if normalize_audio and metadata.has_audio:
             try:
-                loudnorm_analysis = self._run_loudnorm_analysis(video_file)
+                pre_filter = create_denoise_audio_filter(denoise_level) if denoise else ""
+                loudnorm_analysis = self._run_loudnorm_analysis(video_file, pre_filter=pre_filter)
                 logger.info(
                     f"Loudnorm: I={loudnorm_analysis.input_i:.1f}dB "
                     f"TP={loudnorm_analysis.input_tp:.1f}dB "


### PR DESCRIPTION
## 요약

- loudnorm 1st pass(측정)와 2nd pass(적용) 간 오디오 특성 불일치로 인한 오디오 손실 수정
- denoise 활성 시 1st pass도 denoise 필터를 통한 오디오를 측정하도록 변경

## 원인

`--denoise + --normalize-audio` 동시 사용 시 발생하는 버그:

```
기존 동작 (잘못됨):
  1st pass: 원본 오디오 → loudnorm 측정 (I, TP, LRA 값 획득)
  2nd pass: denoise(afftdn) → loudnorm 보정 적용

문제: 1st pass는 원본을, 2nd pass는 denoise된 오디오를 대상으로 하므로
      측정값이 실제 입력과 불일치 → 예측 불가한 보정 → 오디오 손실
```

## 수정

```python
# transcoder.py - loudnorm 1st pass 분석 시 denoise 필터 포함
pre_filter = create_denoise_audio_filter(denoise_level) if denoise else ""
loudnorm_analysis = self._run_loudnorm_analysis(video_file, pre_filter=pre_filter)
```

`_run_loudnorm_analysis(pre_filter="afftdn=nr=12")` 호출 시:
- 분석 필터: `afftdn=nr=12,loudnorm=I=-14:TP=-1.5:LRA=11:print_format=json`
- 1st pass와 2nd pass 모두 동일한 denoise → loudnorm 순서로 처리되어 측정값 일치

## 테스트 계획

- [x] `denoise=True + normalize_audio=True` → 1st pass 분석 명령에 `afftdn` 포함 확인
- [x] `denoise=False + normalize_audio=True` → 1st pass에 `afftdn` 미포함 확인
- [x] 전체 단위 테스트 1254개 통과
- [ ] 실제 DJI Osmo Action 6 영상으로 재현 검증 (사용자 측 확인 필요)

## 관련

Closes #66