### PR TITLE
feat(cli): --video-denoise / --wb-* 플래그 전 스택 연결

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1158,6 +1158,7 @@ class TestValidateArgs:
         def _capture_validate_args(
             parsed_args: argparse.Namespace,
             device_luts: dict[str, str] | None = None,
+            device_wb: dict[str, str] | None = None,
             hooks: HooksConfig | None = None,
         ) -> object:
             # reload 시점에 validate_args로 들어오는 hook 설정을 기록

--- a/tests/unit/test_cli_wb_denoise.py
+++ b/tests/unit/test_cli_wb_denoise.py
@@ -1,0 +1,204 @@
+"""CLI 화이트밸런스 / 영상 노이즈 제거 옵션 검증 테스트."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tubearchive.app.cli.validators import validate_args
+from tubearchive.infra.ffmpeg.constants import WB_PRESETS
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    """최소 필수 필드만 포함한 Namespace를 만든다.
+    나머지는 validate_args 내부의 getattr 기본값에 맡긴다.
+    """
+    defaults: dict[str, object] = {
+        "targets": [],
+        "output": None,
+        "output_dir": None,
+        "parallel": None,
+        "no_resume": False,
+        "keep_temp": False,
+        "dry_run": False,
+        # WB / video_denoise 관련 기본값
+        "video_denoise": False,
+        "video_denoise_level": None,
+        "wb_preset": None,
+        "wb_kelvin": None,
+        "auto_white_balance": None,
+        "no_auto_white_balance": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+@pytest.fixture()
+def valid_args(tmp_path: Path) -> argparse.Namespace:
+    target = tmp_path / "video.mp4"
+    target.write_bytes(b"fake")
+    return _make_args(targets=[str(target)])
+
+
+class TestVideoDenoise:
+    """--video-denoise / --video-denoise-level 검증."""
+
+    def test_video_denoise_default_off(self, valid_args: argparse.Namespace) -> None:
+        result = validate_args(valid_args)
+        assert result.video_denoise is False
+        assert result.video_denoise_strength == "medium"
+
+    def test_video_denoise_flag_enables(self, valid_args: argparse.Namespace) -> None:
+        valid_args.video_denoise = True
+        result = validate_args(valid_args)
+        assert result.video_denoise is True
+
+    def test_video_denoise_level_implies_enable(self, valid_args: argparse.Namespace) -> None:
+        valid_args.video_denoise_level = "heavy"
+        result = validate_args(valid_args)
+        assert result.video_denoise is True
+        assert result.video_denoise_strength == "heavy"
+
+    def test_video_denoise_level_light(self, valid_args: argparse.Namespace) -> None:
+        valid_args.video_denoise = True
+        valid_args.video_denoise_level = "light"
+        result = validate_args(valid_args)
+        assert result.video_denoise_strength == "light"
+
+    @patch("tubearchive.app.cli.validators.get_default_video_denoise", return_value=True)
+    @patch("tubearchive.app.cli.validators.get_default_video_denoise_level", return_value="heavy")
+    def test_env_fallback(
+        self, _mock_level: object, _mock_flag: object, valid_args: argparse.Namespace
+    ) -> None:
+        result = validate_args(valid_args)
+        assert result.video_denoise is True
+        assert result.video_denoise_strength == "heavy"
+
+
+class TestWbPreset:
+    """--wb-preset 검증."""
+
+    def test_wb_preset_daylight(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_preset = "daylight"
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == WB_PRESETS["daylight"]
+
+    def test_wb_preset_cloudy(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_preset = "cloudy"
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == WB_PRESETS["cloudy"]
+
+    def test_invalid_preset_raises(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_preset = "invalid_preset"
+        with pytest.raises(ValueError, match="wb-preset"):
+            validate_args(valid_args)
+
+    def test_no_wb_default_none(self, valid_args: argparse.Namespace) -> None:
+        result = validate_args(valid_args)
+        assert result.wb_kelvin is None
+
+
+class TestWbKelvin:
+    """--wb-kelvin 검증."""
+
+    def test_wb_kelvin_valid(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_kelvin = 5500
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == 5500
+
+    def test_wb_kelvin_overrides_preset(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_preset = "daylight"
+        valid_args.wb_kelvin = 4000
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == 4000
+
+    def test_wb_kelvin_out_of_range_raises(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_kelvin = 999
+        with pytest.raises(ValueError, match="wb-kelvin"):
+            validate_args(valid_args)
+
+    def test_wb_kelvin_upper_bound_raises(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_kelvin = 40001
+        with pytest.raises(ValueError, match="wb-kelvin"):
+            validate_args(valid_args)
+
+    def test_wb_kelvin_boundary_valid(self, valid_args: argparse.Namespace) -> None:
+        valid_args.wb_kelvin = 1000
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == 1000
+
+        valid_args.wb_kelvin = 40000
+        result = validate_args(valid_args)
+        assert result.wb_kelvin == 40000
+
+
+class TestAutoWhiteBalance:
+    """--auto-wb / --no-auto-wb 검증."""
+
+    def test_auto_wb_default_off(self, valid_args: argparse.Namespace) -> None:
+        result = validate_args(valid_args)
+        assert result.auto_white_balance is False
+
+    def test_auto_wb_flag(self, valid_args: argparse.Namespace) -> None:
+        valid_args.auto_white_balance = True
+        result = validate_args(valid_args)
+        assert result.auto_white_balance is True
+
+    def test_no_auto_wb_overrides_env(self, valid_args: argparse.Namespace) -> None:
+        valid_args.no_auto_white_balance = True
+        with patch(
+            "tubearchive.app.cli.validators.get_default_auto_white_balance", return_value=True
+        ):
+            result = validate_args(valid_args)
+        assert result.auto_white_balance is False
+
+    @patch("tubearchive.app.cli.validators.get_default_auto_white_balance", return_value=True)
+    def test_env_auto_wb_fallback(self, _mock: object, valid_args: argparse.Namespace) -> None:
+        result = validate_args(valid_args)
+        assert result.auto_white_balance is True
+
+
+class TestResolveAutoWb:
+    """_resolve_auto_wb() 단위 테스트."""
+
+    def test_matches_device_model(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb("GoPro HERO12", {"gopro": "cloudy"})
+        assert result == WB_PRESETS["cloudy"]
+
+    def test_case_insensitive(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb("NIKON Z6III", {"nikon": "daylight"})
+        assert result == WB_PRESETS["daylight"]
+
+    def test_longest_keyword_wins(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb(
+            "GoPro HERO12",
+            {"go": "tungsten", "gopro": "cloudy"},
+        )
+        assert result == WB_PRESETS["cloudy"]
+
+    def test_no_match_returns_none(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb("Sony A7IV", {"nikon": "daylight"})
+        assert result is None
+
+    def test_empty_device_model_returns_none(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb("", {"gopro": "cloudy"})
+        assert result is None
+
+    def test_empty_device_wb_returns_none(self) -> None:
+        from tubearchive.domain.media.transcoder import _resolve_auto_wb
+
+        result = _resolve_auto_wb("GoPro HERO12", {})
+        assert result is None

--- a/tests/unit/test_cli_wb_denoise.py
+++ b/tests/unit/test_cli_wb_denoise.py
@@ -77,6 +77,16 @@ class TestVideoDenoise:
         assert result.video_denoise is True
         assert result.video_denoise_strength == "heavy"
 
+    @patch("tubearchive.app.cli.validators.get_default_video_denoise", return_value=False)
+    @patch("tubearchive.app.cli.validators.get_default_video_denoise_level", return_value="light")
+    def test_env_level_only_implies_enable(
+        self, _mock_level: object, _mock_flag: object, valid_args: argparse.Namespace
+    ) -> None:
+        """환경변수에서 level만 지정해도 활성화 (오디오 denoise와 동일 패턴)."""
+        result = validate_args(valid_args)
+        assert result.video_denoise is True
+        assert result.video_denoise_strength == "light"
+
 
 class TestWbPreset:
     """--wb-preset 검증."""
@@ -159,6 +169,37 @@ class TestAutoWhiteBalance:
     def test_env_auto_wb_fallback(self, _mock: object, valid_args: argparse.Namespace) -> None:
         result = validate_args(valid_args)
         assert result.auto_white_balance is True
+
+    def test_both_flags_warning(
+        self, valid_args: argparse.Namespace, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """--auto-wb와 --no-auto-wb를 동시에 지정 시 경고 출력 + --no-auto-wb 우선."""
+        import logging
+
+        valid_args.auto_white_balance = True
+        valid_args.no_auto_white_balance = True
+        with caplog.at_level(logging.WARNING, logger="tubearchive.app.cli.validators"):
+            result = validate_args(valid_args)
+        assert result.auto_white_balance is False
+        assert any("--no-auto-wb wins" in m for m in caplog.messages)
+
+
+class TestDeviceWbConfig:
+    """validate_args(device_wb=...) 파라미터로 config의 device_wb 전달 검증."""
+
+    def test_device_wb_param_threaded_through(self, valid_args: argparse.Namespace) -> None:
+        device_wb = {"gopro": "cloudy", "nikon": "daylight"}
+        result = validate_args(valid_args, device_wb=device_wb)
+        assert result.device_wb == device_wb
+
+    def test_device_wb_default_none(self, valid_args: argparse.Namespace) -> None:
+        result = validate_args(valid_args)
+        assert result.device_wb is None
+
+    def test_device_wb_empty_dict_normalized_to_none(self, valid_args: argparse.Namespace) -> None:
+        """빈 dict은 None으로 정규화 (config.toml에 섹션이 없는 경우와 동등)."""
+        result = validate_args(valid_args, device_wb={})
+        assert result.device_wb is None
 
 
 class TestResolveAutoWb:

--- a/tubearchive/app/cli/main.py
+++ b/tubearchive/app/cli/main.py
@@ -443,11 +443,13 @@ def main() -> None:
             cmd_upload_only(args, hooks=config.hooks)
             return
 
-        # config의 device_luts를 validate_args에 전달하여 초기화 시 주입
+        # config의 device_luts/device_wb를 validate_args에 전달하여 초기화 시 주입
         cfg_device_luts = config.color_grading.device_luts or None
+        cfg_device_wb = config.color_grading.device_wb or None
         validated_args = validate_args(
             args,
             device_luts=cfg_device_luts,
+            device_wb=cfg_device_wb,
             hooks=config.hooks,
         )
 

--- a/tubearchive/app/cli/parser.py
+++ b/tubearchive/app/cli/parser.py
@@ -224,6 +224,21 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--video-denoise",
+        action="store_true",
+        help="영상 노이즈 제거 활성화 (hqdn3d)",
+    )
+
+    parser.add_argument(
+        "--video-denoise-level",
+        type=str,
+        choices=["light", "medium", "heavy"],
+        default=None,
+        dest="video_denoise_level",
+        help="영상 노이즈 제거 강도 (light/medium/heavy, 기본: medium)",
+    )
+
+    parser.add_argument(
         "--normalize-audio",
         action="store_true",
         help="EBU R128 오디오 라우드니스 정규화 활성화 (loudnorm 2-pass)",
@@ -535,6 +550,40 @@ def create_parser() -> argparse.ArgumentParser:
         "--lut-before-hdr",
         action="store_true",
         help="LUT를 HDR→SDR 변환 전에 적용 (기본: HDR 변환 후 적용)",
+    )
+
+    # 화이트밸런스 옵션
+    parser.add_argument(
+        "--wb-preset",
+        type=str,
+        choices=["tungsten", "fluorescent", "daylight", "cloudy", "shade"],
+        default=None,
+        dest="wb_preset",
+        help="화이트밸런스 프리셋 (tungsten/fluorescent/daylight/cloudy/shade)",
+    )
+
+    parser.add_argument(
+        "--wb-kelvin",
+        type=int,
+        default=None,
+        dest="wb_kelvin",
+        metavar="K",
+        help="화이트밸런스 색온도 직접 지정 (1000-40000K). --wb-preset보다 우선.",
+    )
+
+    parser.add_argument(
+        "--auto-wb",
+        action="store_true",
+        default=None,
+        dest="auto_white_balance",
+        help="기기 모델 기반 자동 화이트밸런스 적용 (config.toml [color_grading.device_wb] 참조)",
+    )
+
+    parser.add_argument(
+        "--no-auto-wb",
+        action="store_true",
+        dest="no_auto_white_balance",
+        help="자동 화이트밸런스 비활성화 (환경변수/config 설정 무시)",
     )
 
     parser.add_argument(

--- a/tubearchive/app/cli/parser.py
+++ b/tubearchive/app/cli/parser.py
@@ -22,6 +22,7 @@ from tubearchive.domain.media.subtitle import (
     SubtitleFormat,
     SubtitleModel,
 )
+from tubearchive.infra.ffmpeg.constants import WB_PRESETS
 
 logger = logging.getLogger(__name__)
 
@@ -553,13 +554,14 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     # 화이트밸런스 옵션
+    _wb_preset_choices = sorted(WB_PRESETS)
     parser.add_argument(
         "--wb-preset",
         type=str,
-        choices=["tungsten", "fluorescent", "daylight", "cloudy", "shade"],
+        choices=_wb_preset_choices,
         default=None,
         dest="wb_preset",
-        help="화이트밸런스 프리셋 (tungsten/fluorescent/daylight/cloudy/shade)",
+        help=f"화이트밸런스 프리셋 ({'/'.join(_wb_preset_choices)})",
     )
 
     parser.add_argument(

--- a/tubearchive/app/cli/pipeline.py
+++ b/tubearchive/app/cli/pipeline.py
@@ -151,6 +151,11 @@ class TranscodeOptions:
     auto_lut: bool = False
     lut_before_hdr: bool = False
     device_luts: dict[str, str] | None = None
+    video_denoise: bool = False
+    video_denoise_strength: str = "medium"
+    wb_kelvin: int | None = None
+    auto_white_balance: bool = False
+    device_wb: dict[str, str] | None = None
     watermark_text: str | None = None
     watermark_pos: str = "bottom-right"
     watermark_size: int = 48
@@ -555,6 +560,11 @@ def _transcode_single(
             auto_lut=opts.auto_lut,
             lut_before_hdr=opts.lut_before_hdr,
             device_luts=opts.device_luts,
+            video_denoise=opts.video_denoise,
+            video_denoise_strength=opts.video_denoise_strength,
+            wb_kelvin=opts.wb_kelvin,
+            auto_white_balance=opts.auto_white_balance,
+            device_wb=opts.device_wb,
             watermark_text=watermark_text,
             watermark_position=opts.watermark_pos,
             watermark_size=opts.watermark_size,
@@ -728,6 +738,11 @@ def _transcode_sequential(
                     auto_lut=opts.auto_lut,
                     lut_before_hdr=opts.lut_before_hdr,
                     device_luts=opts.device_luts,
+                    video_denoise=opts.video_denoise,
+                    video_denoise_strength=opts.video_denoise_strength,
+                    wb_kelvin=opts.wb_kelvin,
+                    auto_white_balance=opts.auto_white_balance,
+                    device_wb=opts.device_wb,
                     watermark_text=watermark_text,
                     watermark_position=opts.watermark_pos,
                     watermark_size=opts.watermark_size,
@@ -1034,6 +1049,11 @@ def run_pipeline(
         auto_lut=validated_args.auto_lut,
         lut_before_hdr=validated_args.lut_before_hdr,
         device_luts=validated_args.device_luts,
+        video_denoise=validated_args.video_denoise,
+        video_denoise_strength=validated_args.video_denoise_strength,
+        wb_kelvin=validated_args.wb_kelvin,
+        auto_white_balance=validated_args.auto_white_balance,
+        device_wb=validated_args.device_wb,
         watermark=validated_args.watermark,
         watermark_text=validated_args.watermark_text or None,
         watermark_pos=validated_args.watermark_pos,

--- a/tubearchive/app/cli/validators.py
+++ b/tubearchive/app/cli/validators.py
@@ -195,6 +195,7 @@ def _resolve_template_path(template_arg: str | Path | None) -> Path | None:
 def validate_args(
     args: argparse.Namespace,
     device_luts: dict[str, str] | None = None,
+    device_wb: dict[str, str] | None = None,
     hooks: HooksConfig | None = None,
 ) -> ValidatedArgs:
     """CLI 인자를 검증하고 :class:`ValidatedArgs` 로 변환한다.
@@ -480,11 +481,12 @@ def validate_args(
     lut_before_hdr: bool = getattr(args, "lut_before_hdr", False)
 
     # 영상 노이즈 제거 (CLI > 환경변수 > 기본값)
+    # 환경변수에서 level만 지정해도 활성화로 간주 (오디오 denoise와 동일 패턴)
     video_denoise_flag = bool(getattr(args, "video_denoise", False))
     video_denoise_level_arg = getattr(args, "video_denoise_level", None)
     env_video_denoise = get_default_video_denoise()
     env_video_denoise_level = get_default_video_denoise_level()
-    video_denoise = video_denoise_flag or env_video_denoise
+    video_denoise = video_denoise_flag or env_video_denoise or (env_video_denoise_level is not None)
     resolved_video_denoise_level = video_denoise_level_arg or env_video_denoise_level or "medium"
     if video_denoise_level_arg is not None:
         video_denoise = True
@@ -508,7 +510,10 @@ def validate_args(
 
     auto_wb_flag = getattr(args, "auto_white_balance", None)
     no_auto_wb_flag = getattr(args, "no_auto_white_balance", False)
+    # --no-auto-wb이 --auto-wb보다 우선 (명시적 비활성화)
     if no_auto_wb_flag:
+        if auto_wb_flag:
+            logger.warning("--auto-wb and --no-auto-wb both set; --no-auto-wb wins")
         auto_white_balance = False
     elif auto_wb_flag:
         auto_white_balance = True
@@ -606,7 +611,7 @@ def validate_args(
         video_denoise_strength=resolved_video_denoise_level,
         wb_kelvin=resolved_wb_kelvin,
         auto_white_balance=auto_white_balance,
-        device_wb=None,
+        device_wb=device_wb if device_wb else None,
         watermark=watermark_enabled,
         watermark_pos=watermark_pos,
         watermark_size=watermark_size,

--- a/tubearchive/app/cli/validators.py
+++ b/tubearchive/app/cli/validators.py
@@ -11,6 +11,7 @@ from tubearchive.app.cli.parser import parse_schedule_datetime
 from tubearchive.config import (
     HooksConfig,
     get_default_auto_lut,
+    get_default_auto_white_balance,
     get_default_backup_include_originals,
     get_default_backup_remote,
     get_default_bgm_loop,
@@ -33,6 +34,8 @@ from tubearchive.config import (
     get_default_subtitle_model,
     get_default_template_intro,
     get_default_template_outro,
+    get_default_video_denoise,
+    get_default_video_denoise_level,
     get_default_watch_log_path,
     get_default_watch_paths,
     get_default_watch_poll_interval,
@@ -44,6 +47,7 @@ from tubearchive.domain.media.subtitle import (
     SubtitleFormat,
     SubtitleModel,
 )
+from tubearchive.infra.ffmpeg.constants import WB_PRESETS
 from tubearchive.infra.ffmpeg.effects import LUT_SUPPORTED_EXTENSIONS
 from tubearchive.shared.validators import ValidationError
 
@@ -111,6 +115,11 @@ class ValidatedArgs:
     auto_lut: bool = False
     lut_before_hdr: bool = False
     device_luts: dict[str, str] | None = None
+    video_denoise: bool = False
+    video_denoise_strength: str = "medium"
+    wb_kelvin: int | None = None
+    auto_white_balance: bool = False
+    device_wb: dict[str, str] | None = None
     template_intro: Path | None = None
     template_outro: Path | None = None
     watermark: bool = False
@@ -469,6 +478,43 @@ def validate_args(
         auto_lut = get_default_auto_lut()
 
     lut_before_hdr: bool = getattr(args, "lut_before_hdr", False)
+
+    # 영상 노이즈 제거 (CLI > 환경변수 > 기본값)
+    video_denoise_flag = bool(getattr(args, "video_denoise", False))
+    video_denoise_level_arg = getattr(args, "video_denoise_level", None)
+    env_video_denoise = get_default_video_denoise()
+    env_video_denoise_level = get_default_video_denoise_level()
+    video_denoise = video_denoise_flag or env_video_denoise
+    resolved_video_denoise_level = video_denoise_level_arg or env_video_denoise_level or "medium"
+    if video_denoise_level_arg is not None:
+        video_denoise = True
+
+    # 화이트밸런스 (CLI > 환경변수 > 기본값)
+    # --wb-preset 지정 시 Kelvin 변환, --wb-kelvin은 직접 사용
+    wb_preset_arg: str | None = getattr(args, "wb_preset", None)
+    wb_kelvin_arg: int | None = getattr(args, "wb_kelvin", None)
+    resolved_wb_kelvin: int | None = None
+    if wb_kelvin_arg is not None:
+        if not (1000 <= wb_kelvin_arg <= 40000):
+            raise ValueError(f"--wb-kelvin must be 1000-40000, got: {wb_kelvin_arg}")
+        resolved_wb_kelvin = wb_kelvin_arg
+    elif wb_preset_arg is not None:
+        if wb_preset_arg not in WB_PRESETS:
+            raise ValueError(
+                f"--wb-preset {wb_preset_arg!r} is not valid. "
+                f"Valid presets: {', '.join(sorted(WB_PRESETS))}"
+            )
+        resolved_wb_kelvin = WB_PRESETS[wb_preset_arg]
+
+    auto_wb_flag = getattr(args, "auto_white_balance", None)
+    no_auto_wb_flag = getattr(args, "no_auto_white_balance", False)
+    if no_auto_wb_flag:
+        auto_white_balance = False
+    elif auto_wb_flag:
+        auto_white_balance = True
+    else:
+        auto_white_balance = get_default_auto_white_balance()
+
     # 템플릿 옵션 (CLI > env/config)
     template_intro_env = get_default_template_intro()
     template_outro_env = get_default_template_outro()
@@ -556,6 +602,11 @@ def validate_args(
         lut_path=lut_path,
         auto_lut=auto_lut,
         lut_before_hdr=lut_before_hdr,
+        video_denoise=video_denoise,
+        video_denoise_strength=resolved_video_denoise_level,
+        wb_kelvin=resolved_wb_kelvin,
+        auto_white_balance=auto_white_balance,
+        device_wb=None,
         watermark=watermark_enabled,
         watermark_pos=watermark_pos,
         watermark_size=watermark_size,

--- a/tubearchive/app/cli/watch.py
+++ b/tubearchive/app/cli/watch.py
@@ -162,6 +162,7 @@ def _run_watch_mode(
         return validate_args(
             parsed_args,
             device_luts=updated_config.color_grading.device_luts or None,
+            device_wb=updated_config.color_grading.device_wb or None,
             hooks=updated_config.hooks,
         )
 

--- a/tubearchive/domain/media/transcoder.py
+++ b/tubearchive/domain/media/transcoder.py
@@ -41,6 +41,41 @@ from tubearchive.shared.progress import ProgressInfo
 logger = logging.getLogger(__name__)
 
 
+def _resolve_auto_wb(device_model: str, device_wb: dict[str, str]) -> int | None:
+    """기기 모델명 기반으로 WB 프리셋을 자동 매칭하여 Kelvin 값을 반환한다.
+
+    부분 문자열 매칭(대소문자 무시)을 사용하며,
+    다중 매칭 시 가장 긴 키워드(가장 구체적)를 우선한다.
+
+    Args:
+        device_model: FFprobe에서 감지된 기기 모델명
+        device_wb: 기기 키워드 → WB 프리셋 이름 매핑
+
+    Returns:
+        매칭된 WB 프리셋의 Kelvin 값 또는 None
+    """
+    from tubearchive.infra.ffmpeg.constants import WB_PRESETS
+
+    if not device_model or not device_wb:
+        return None
+
+    model_lower = device_model.lower()
+    matches: list[tuple[int, str]] = []
+
+    for keyword, preset in device_wb.items():
+        if not keyword:
+            continue
+        if keyword.lower() in model_lower:
+            matches.append((len(keyword), preset))
+
+    if not matches:
+        return None
+
+    matches.sort(key=lambda x: x[0], reverse=True)
+    best_preset = matches[0][1]
+    return WB_PRESETS.get(best_preset)
+
+
 def _resolve_auto_lut(device_model: str, device_luts: dict[str, str]) -> str | None:
     """기기 모델명 기반으로 LUT 파일 경로를 자동 매칭한다.
 
@@ -374,6 +409,11 @@ class Transcoder:
         auto_lut: bool = False,
         lut_before_hdr: bool = False,
         device_luts: dict[str, str] | None = None,
+        video_denoise: bool = False,
+        video_denoise_strength: str = "medium",
+        wb_kelvin: int | None = None,
+        auto_white_balance: bool = False,
+        device_wb: dict[str, str] | None = None,
         metadata: VideoMetadata | None = None,
         watermark_text: str | None = None,
         watermark_position: str = "bottom-right",
@@ -405,6 +445,11 @@ class Transcoder:
             auto_lut: 기기 모델 기반 자동 LUT 매칭 활성화
             lut_before_hdr: LUT 필터를 HDR→SDR 변환 전에 적용
             device_luts: 기기 키워드 → LUT 파일 경로 매핑
+            video_denoise: 영상 노이즈 제거(hqdn3d) 활성화 여부
+            video_denoise_strength: 영상 노이즈 제거 강도 (light/medium/heavy)
+            wb_kelvin: 화이트밸런스 색온도 직접 지정 (K). auto_white_balance보다 우선.
+            auto_white_balance: 기기 모델 기반 자동 WB 매칭 활성화
+            device_wb: 기기 키워드 → WB 프리셋 이름 매핑 (없으면 WB_DEVICE_DEFAULTS 사용)
             metadata: 외부에서 전달된 메타데이터(없으면 감지 실행)
             watermark_text: 워터마크 텍스트
             watermark_position: 워터마크 위치
@@ -523,6 +568,18 @@ class Transcoder:
             if resolved_lut:
                 logger.info(f"Auto-LUT matched: {resolved_lut} for {metadata.device_model}")
 
+        # 5.9 WB 해석 (wb_kelvin 직접 지정 > auto_white_balance 매칭)
+        resolved_wb_kelvin: int | None = wb_kelvin
+        if resolved_wb_kelvin is None and auto_white_balance and metadata.device_model:
+            from tubearchive.infra.ffmpeg.constants import WB_DEVICE_DEFAULTS
+
+            effective_device_wb = device_wb if device_wb else dict(WB_DEVICE_DEFAULTS)
+            resolved_wb_kelvin = _resolve_auto_wb(metadata.device_model, effective_device_wb)
+            if resolved_wb_kelvin:
+                logger.info(
+                    "Auto-WB matched: %dK for %s", resolved_wb_kelvin, metadata.device_model
+                )
+
         def _build_filters(include_watermark: bool) -> tuple[str, str]:
             return create_combined_filter(
                 source_width=metadata.width,
@@ -540,6 +597,9 @@ class Transcoder:
                 denoise_level=denoise_level,
                 silence_remove=silence_remove_filter,
                 loudnorm_analysis=loudnorm_analysis,
+                video_denoise=video_denoise,
+                video_denoise_strength=video_denoise_strength,
+                wb_kelvin=resolved_wb_kelvin,
                 lut_path=resolved_lut,
                 lut_before_hdr=lut_before_hdr,
                 watermark_text=watermark_text if include_watermark else None,

--- a/tubearchive/domain/media/transcoder.py
+++ b/tubearchive/domain/media/transcoder.py
@@ -575,7 +575,7 @@ class Transcoder:
 
             effective_device_wb = device_wb if device_wb else dict(WB_DEVICE_DEFAULTS)
             resolved_wb_kelvin = _resolve_auto_wb(metadata.device_model, effective_device_wb)
-            if resolved_wb_kelvin:
+            if resolved_wb_kelvin is not None:
                 logger.info(
                     "Auto-WB matched: %dK for %s", resolved_wb_kelvin, metadata.device_model
                 )


### PR DESCRIPTION
## Summary

- `--video-denoise`, `--video-denoise-level`: 영상 노이즈 제거(hqdn3d) 활성화 및 강도 제어
- `--wb-preset`: 프리셋(tungsten/fluorescent/daylight/cloudy/shade) 기반 화이트밸런스
- `--wb-kelvin`: 색온도 직접 지정 (1000–40000K), `--wb-preset` 보다 우선
- `--auto-wb` / `--no-auto-wb`: 기기 모델 기반 자동 화이트밸런스 (exiftool 연동)

전 계층 연결: `parser` → `validators` → `pipeline(TranscodeOptions)` → `transcoder`

## Changes

- `parser.py`: 6개 인수 추가 (`--video-denoise`, `--video-denoise-level`, `--wb-preset`, `--wb-kelvin`, `--auto-wb`, `--no-auto-wb`)
- `validators.py`: `ValidatedArgs`에 5개 필드 추가; CLI > ENV > 기본값 우선순위 검증
- `pipeline.py`: `TranscodeOptions`에 5개 필드 추가, `transcode_video()` 순차·병렬 호출부 업데이트
- `transcoder.py`: `_resolve_auto_wb()` (기기 모델 KW 최장 매칭) 신규, `transcode_video()` 시그니처 확장
- `tests/unit/test_cli_wb_denoise.py`: 신규 24개 테스트 (5개 클래스)

## Test plan

- [x] `uv run pytest tests/unit/test_cli_wb_denoise.py` — 24/24 통과
- [x] `uv run pytest tests/unit/` — 1553/1553 통과
- [x] `uv run mypy tubearchive/` — 오류 없음
- [x] `uv run ruff check tubearchive/ tests/` — 오류 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video denoise with adjustable strength (light/medium/heavy) and flags to enable/disable.
  * White balance controls: presets and manual Kelvin (1000–40000K), plus auto-WB with CLI enable/disable and device-based detection/lookup.

* **Behavior**
  * Explicit Kelvin overrides presets; auto-WB precedence and warning when conflicting flags provided.
  * Device-specific WB mappings accepted and normalized.

* **Tests**
  * Expanded tests covering CLI validation, auto-WB resolution, presets, kelvin bounds, and device-WB behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->